### PR TITLE
Updated an out-of-date import: `from celery.utils.functional import prom...

### DIFF
--- a/cyme/utils/__init__.py
+++ b/cyme/utils/__init__.py
@@ -7,7 +7,7 @@ from importlib import import_module
 
 from celery import current_app as celery
 from celery.utils import get_cls_by_name
-from celery.utils import promise, maybe_promise # noqa
+from celery.utils.functional import promise, maybe_promise # noqa
 from kombu.utils import uuid, cached_property   # noqa
 from unipath import Path as _Path
 


### PR DESCRIPTION
...ise, maybe_promise`works with my up-to-date Celery (the standing version omits the`functional` and as such it failed to start).
