### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -88,8 +88,8 @@ latex_documents = [
 html_show_sphinx = False
 intersphinx_mapping = {
         "http://docs.python.org/dev": None,
-        "http://kombu.readthedocs.org/en/latest/": None,
-        "http://django-celery.readthedocs.org/en/latest": None,
+        "https://kombu.readthedocs.io/en/latest/": None,
+        "https://django-celery.readthedocs.io/en/latest": None,
 }
 
 html_theme = "celery"


### PR DESCRIPTION
As per their email ‘Changes to project subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
